### PR TITLE
Add explicit $templateCache annotation in non optimized code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,7 +133,7 @@
       if (this.optimize) {
         return ("angular.module('" + moduleName + "',[])") + (".run(['$templateCache',function(t){" + data + "\n}])");
       } else {
-        return "angular.module('" + moduleName + "', []).run(function($templateCache) {\n" + data + "\n});\n";
+        return "angular.module('" + moduleName + "', []).run(['$templateCache',function($templateCache) {\n" + data + "\n}]);\n";
       }
     };
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -104,9 +104,9 @@ module.exports = class JadeNgtemplates
       ".run(['$templateCache',function(t){#{data}\n}])"
     else
       """
-      angular.module('#{moduleName}', []).run(function($templateCache) {
+      angular.module('#{moduleName}', []).run(['$templateCache',function($templateCache) {
       #{data}
-      });
+      }]);
 
       """
 


### PR DESCRIPTION
Thank you for this great plugin!
I was attempting to use it with ng-strict-di enabled, but end up receiving an error because the generated templateCache funcion wasn't being annotated. The only way I found to make it work is changing the code directly. This PR fixes this issue.
